### PR TITLE
Add launcher HTML with placeholders

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Visualization Launcher</title>
+<style>
+body {
+    font-family: Arial, sans-serif;
+    background: #f0f0f0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+    margin: 0;
+}
+.grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 20px;
+    width: 80%;
+    max-width: 800px;
+}
+.button {
+    text-decoration: none;
+    color: #333;
+    background: #fff;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+    transition: transform 0.2s;
+}
+.button:hover {
+    transform: translateY(-4px);
+}
+.icon {
+    font-size: 48px;
+    margin-bottom: 10px;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+    <a class="button" href="mandelbrot/index.html">
+        <div class="icon">🌀</div>
+        <div>Mandelbrot</div>
+    </a>
+    <a class="button" href="particles/index.html">
+        <div class="icon">✨</div>
+        <div>Particles</div>
+    </a>
+    <a class="button" href="spirograph/index.html">
+        <div class="icon">🧩</div>
+        <div>Spirograph</div>
+    </a>
+</div>
+</body>
+</html>

--- a/mandelbrot/index.html
+++ b/mandelbrot/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Mandelbrot</title>
+</head>
+<body>
+<h1>Mandelbrot Visualization</h1>
+<p>Coming soon!</p>
+</body>
+</html>

--- a/particles/index.html
+++ b/particles/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Particles</title>
+</head>
+<body>
+<h1>Particles Visualization</h1>
+<p>Coming soon!</p>
+</body>
+</html>

--- a/spirograph/index.html
+++ b/spirograph/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Spirograph</title>
+</head>
+<body>
+<h1>Spirograph Visualization</h1>
+<p>Coming soon!</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `index.html` grid launcher similar to Heimdall
- create placeholder visualizer folders and minimal HTML pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68524e4c0e088325b9f18cb42583114a