### PR TITLE
Fix visibility issue in layered visualizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Open `layered/index.html` in a browser to see a customizable multi-layer
 visualization. Press **Toggle Settings** in the top-right corner to reveal
 controls for each layer. Three layers are created by default and you can adjust
 shape, offsets, scaling, colour, blur amount, parallax strength and animation
-speed in real time. Shapes are filled with translucent colours (about 30% opacity) that blend together with a soft glow while previous frames fade slowly for a trailing effect. You can add or remove layers on the fly, save the current configuration
+speed in real time. Shapes are filled with translucent colours (about 30% opacity) that blend together with a soft glow while previous frames fade slowly for a trailing effect. Each layer's background is transparent so the layers stack visually. You can add or remove layers on the fly, save the current configuration
 as JSON to local storage or the provided textarea and load it later, choose from
 several presets or randomize all layer settings with a single click.
 

--- a/layered/index.html
+++ b/layered/index.html
@@ -137,8 +137,10 @@ window.addEventListener('mousemove',e=>{
 function animate(time){
     layers.forEach(l=>{
         const {ctx, canvas, params}=l;
+        ctx.globalCompositeOperation='destination-out';
         ctx.fillStyle='rgba(0,0,0,0.1)';
         ctx.fillRect(0,0,canvas.width,canvas.height);
+        ctx.globalCompositeOperation='lighter';
         ctx.save();
         ctx.translate(
             canvas.width/2+params.offsetX+pointerX*canvas.width*params.parallax,


### PR DESCRIPTION
## Summary
- keep each canvas background transparent so all layers remain visible
- document transparent layers in README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68530052e02c832594bdd33001f4dc21