### PR TITLE
Update layered visualizer with new appearance options

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,11 @@ These projects share a couple of design goals:
 Open `layered/index.html` in a browser to see a customizable multi-layer
 visualization. Press **Toggle Settings** in the top-right corner to reveal
 controls for each layer. Three layers are created by default and you can adjust
-shape, offsets, scaling, colour, blur amount, parallax strength and animation
-speed in real time. Shapes are filled with translucent colours (about 30% opacity) that blend together with a soft glow while previous frames fade slowly for a trailing effect. Each layer's background is transparent so the layers stack visually. You can add or remove layers on the fly, save the current configuration
+shape, offsets, scaling, colour, blur amount, opacity and drift parameters in
+real time. Parallax is now driven by a low frequency oscillator so each layer
+slowly drifts in its own direction while rotating. Shapes can vary in size
+based on a configurable jitter value and the backdrop of each layer can be
+blurred independently. You can add or remove layers on the fly, save the current configuration
 as JSON to local storage or the provided textarea and load it later, choose from
 several presets or randomize all layer settings with a single click.
 

--- a/common.css
+++ b/common.css
@@ -1,4 +1,4 @@
 body{margin:0;overflow:hidden;background:#000;color:#fff;font-family:Arial,sans-serif;}
 .controls{position:absolute;top:10px;right:10px;z-index:10;}
-.settings-panel{position:absolute;top:40px;right:10px;background:rgba(0,0,0,0.8);color:#fff;padding:10px;border:1px solid #555;border-radius:4px;display:none;max-height:90vh;overflow-y:auto;}
+.settings-panel{position:absolute;top:40px;right:10px;background:rgba(0,0,0,0.8);color:#fff;padding:10px;border:1px solid #555;border-radius:4px;display:none;max-height:90vh;overflow-y:auto;z-index:20;}
 label{display:block;margin:4px 0;}

--- a/layered/index.html
+++ b/layered/index.html
@@ -33,6 +33,13 @@ textarea#presetText { width: 100%; height: 5em; }
 </div>
 <div id="settings" class="settings-panel"></div>
 <script>
+const baseParams = {
+    opacity:0.3,
+    backdropBlur:0,
+    sizeVar:0,
+    driftSpeed:1,
+    driftAngle:0
+};
 const defaultParams = [
     {shape:'triangle', scaleX:1, scaleY:1, offsetX:0, offsetY:0, color:'#ff0000', blur:0, speed:1, parallax:0.05},
     {shape:'square',   scaleX:1, scaleY:1, offsetX:0, offsetY:0, color:'#00ff00', blur:0, speed:1, parallax:0.1},
@@ -53,7 +60,6 @@ const presets = {
 };
 
 const layers = [];
-const SHAPE_OPACITY = 0.3; // opacity for translucent shapes
 function createLayer(params){
     const index=layers.length;
     const c=document.createElement('canvas');
@@ -62,7 +68,9 @@ function createLayer(params){
     c.className='layer';
     c.style.zIndex=index;
     document.body.appendChild(c);
-    layers.push({canvas:c,ctx:c.getContext('2d'),params:{...params}});
+    const fullParams={...baseParams,...params};
+    c.style.backdropFilter=`blur(${fullParams.backdropBlur}px)`;
+    layers.push({canvas:c,ctx:c.getContext('2d'),params:fullParams});
 }
 
 for(let i=0;i<3;i++) createLayer(defaultParams[i]);
@@ -87,6 +95,12 @@ function randomizeLayer(l){
     l.params.blur=Math.floor(Math.random()*10);
     l.params.speed=Math.random()*2+0.5;
     l.params.parallax=Math.random()*0.2;
+    l.params.opacity=Math.random()*0.5+0.1;
+    l.params.backdropBlur=Math.floor(Math.random()*10);
+    l.params.sizeVar=Math.random()*0.5;
+    l.params.driftSpeed=Math.random()*1+0.5;
+    l.params.driftAngle=Math.random()*Math.PI*2;
+    l.canvas.style.backdropFilter=`blur(${l.params.backdropBlur}px)`;
 }
 
 function randomizeAll(){
@@ -99,7 +113,8 @@ function applyPreset(name){
     if(!preset) return;
     layers.forEach((l,i)=>{
         const p=preset[i%preset.length];
-        l.params={...p};
+        l.params={...baseParams,...p};
+        l.canvas.style.backdropFilter=`blur(${l.params.backdropBlur}px)`;
     });
     createSettings();
 }
@@ -129,11 +144,6 @@ function drawShape(ctx,shape,size){
     }
     ctx.fill();
 }
-let pointerX=0, pointerY=0;
-window.addEventListener('mousemove',e=>{
-    pointerX=(e.clientX-window.innerWidth/2)/window.innerWidth;
-    pointerY=(e.clientY-window.innerHeight/2)/window.innerHeight;
-});
 function animate(time){
     layers.forEach(l=>{
         const {ctx, canvas, params}=l;
@@ -142,12 +152,13 @@ function animate(time){
         ctx.fillRect(0,0,canvas.width,canvas.height);
         ctx.globalCompositeOperation='lighter';
         ctx.save();
+        const drift=Math.sin(time*0.0002*params.driftSpeed)*params.parallax;
         ctx.translate(
-            canvas.width/2+params.offsetX+pointerX*canvas.width*params.parallax,
-            canvas.height/2+params.offsetY+pointerY*canvas.height*params.parallax
+            canvas.width/2+params.offsetX+Math.cos(params.driftAngle)*drift*canvas.width,
+            canvas.height/2+params.offsetY+Math.sin(params.driftAngle)*drift*canvas.height
         );
         ctx.fillStyle=params.color;
-        ctx.globalAlpha=SHAPE_OPACITY;
+        ctx.globalAlpha=params.opacity;
         ctx.filter=`blur(${params.blur}px)`;
         ctx.globalCompositeOperation='lighter';
         const step=40;
@@ -159,7 +170,8 @@ function animate(time){
                 ctx.save();
                 ctx.translate(x,y);
                 ctx.rotate(rot);
-                drawShape(ctx,params.shape,step*0.8);
+                const jitter=1+(Math.random()*2-1)*params.sizeVar;
+                drawShape(ctx,params.shape,step*0.8*jitter);
                 ctx.restore();
             }
         }
@@ -186,8 +198,13 @@ function createSettings(){
             ['offsetY','number'],
             ['color','color'],
             ['blur','number'],
+            ['opacity','number'],
+            ['backdropBlur','number'],
+            ['sizeVar','number'],
             ['speed','number'],
-            ['parallax','number']
+            ['parallax','number'],
+            ['driftSpeed','number'],
+            ['driftAngle','number']
         ];
         fields.forEach(f=>{
             const label=document.createElement('label');
@@ -204,7 +221,10 @@ function createSettings(){
                 input.value=l.params[f[0]];
                 if(f[1]==='number') input.step='0.1';
             }
-            input.oninput=()=>{ l.params[f[0]]=f[1]==='number'?parseFloat(input.value):input.value; };
+            input.oninput=()=>{
+                l.params[f[0]]=f[1]==='number'?parseFloat(input.value):input.value;
+                if(f[0]==='backdropBlur') l.canvas.style.backdropFilter=`blur(${l.params.backdropBlur}px)`;
+            };
             label.textContent=f[0]+': ';
             label.appendChild(input);
             div.appendChild(label);
@@ -243,8 +263,12 @@ document.getElementById('loadPreset').onclick=()=>{
     try{
         const arr=JSON.parse(data);
         arr.forEach((p,i)=>{
-            if(i<layers.length) layers[i].params={...layers[i].params,...p};
-            else createLayer(p);
+            if(i<layers.length){
+                layers[i].params={...layers[i].params,...p};
+                layers[i].canvas.style.backdropFilter=`blur(${layers[i].params.backdropBlur}px)`;
+            } else {
+                createLayer(p);
+            }
         });
         while(layers.length>arr.length) removeLayer();
         createSettings();


### PR DESCRIPTION
## Summary
- keep settings panel above layers
- introduce new parameters for layer opacity, backdrop blur, size jitter and LFO drift
- implement LFO-driven parallax and per-shape scale variation
- document updated behavior in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685305151e24832598ff8b663e6d01de