### PR TITLE
Add shapes and size range to layered visualizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,12 @@ visualization. Press **Toggle Settings** in the top-right corner to reveal
 controls for each layer. Three layers are created by default and you can adjust
 shape, offsets, scaling, colour, blur amount, opacity and drift parameters in
 real time. Parallax is now driven by a low frequency oscillator so each layer
-slowly drifts in its own direction while rotating. Shapes can vary in size
-based on a configurable jitter value and the backdrop of each layer can be
-blurred independently. You can add or remove layers on the fly, save the current configuration
-as JSON to local storage or the provided textarea and load it later, choose from
+slowly drifts in its own direction while rotating. The visualizer now includes
+circles, diamonds and stars in addition to triangles, squares and hexagons.
+Each layer can specify minimum and maximum size factors for its shapes along
+with a jitter amount. The backdrop of each layer can be blurred independently.
+You can add or remove layers on the fly, save the current configuration as JSON
+to local storage or the provided textarea and load it later, choose from
 several presets or randomize all layer settings with a single click.
 
 ## Triangles Visualizer

--- a/layered/index.html
+++ b/layered/index.html
@@ -37,13 +37,15 @@ const baseParams = {
     opacity:0.3,
     backdropBlur:0,
     sizeVar:0,
+    sizeMin:1,
+    sizeMax:1,
     driftSpeed:1,
     driftAngle:0
 };
 const defaultParams = [
-    {shape:'triangle', scaleX:1, scaleY:1, offsetX:0, offsetY:0, color:'#ff0000', blur:0, speed:1, parallax:0.05},
-    {shape:'square',   scaleX:1, scaleY:1, offsetX:0, offsetY:0, color:'#00ff00', blur:0, speed:1, parallax:0.1},
-    {shape:'hexagon',  scaleX:1, scaleY:1, offsetX:0, offsetY:0, color:'#0000ff', blur:0, speed:1, parallax:0.15},
+    {shape:'triangle', scaleX:1, scaleY:1, offsetX:0, offsetY:0, color:'#ff0000', blur:0, speed:1, parallax:0.05, sizeMin:0.8, sizeMax:1.2},
+    {shape:'square',   scaleX:1, scaleY:1, offsetX:0, offsetY:0, color:'#00ff00', blur:0, speed:1, parallax:0.1,  sizeMin:0.8, sizeMax:1.2},
+    {shape:'hexagon',  scaleX:1, scaleY:1, offsetX:0, offsetY:0, color:'#0000ff', blur:0, speed:1, parallax:0.15, sizeMin:0.8, sizeMax:1.2},
 ];
 const presets = {
     Default: defaultParams,
@@ -85,7 +87,7 @@ function removeLayer(){
 }
 
 function randomizeLayer(l){
-    const shapes=['triangle','square','hexagon'];
+    const shapes=['triangle','square','hexagon','circle','diamond','star'];
     l.params.shape=shapes[Math.floor(Math.random()*shapes.length)];
     l.params.scaleX=Math.random()*1.5+0.5;
     l.params.scaleY=Math.random()*1.5+0.5;
@@ -98,6 +100,8 @@ function randomizeLayer(l){
     l.params.opacity=Math.random()*0.5+0.1;
     l.params.backdropBlur=Math.floor(Math.random()*10);
     l.params.sizeVar=Math.random()*0.5;
+    l.params.sizeMin=Math.random()*0.8+0.4; // 0.4 - 1.2
+    l.params.sizeMax=l.params.sizeMin+Math.random()*1.0; // ensure max >= min
     l.params.driftSpeed=Math.random()*1+0.5;
     l.params.driftAngle=Math.random()*Math.PI*2;
     l.canvas.style.backdropFilter=`blur(${l.params.backdropBlur}px)`;
@@ -141,6 +145,24 @@ function drawShape(ctx,shape,size){
             if(i===0) ctx.moveTo(x,y); else ctx.lineTo(x,y);
         }
         ctx.closePath();
+    } else if(shape==='circle'){
+        ctx.arc(0,0,size/2,0,Math.PI*2);
+    } else if(shape==='diamond'){
+        ctx.moveTo(0,-size/2);
+        ctx.lineTo(size/2,0);
+        ctx.lineTo(0,size/2);
+        ctx.lineTo(-size/2,0);
+        ctx.closePath();
+    } else if(shape==='star'){
+        const points=5;
+        for(let i=0;i<points*2;i++){
+            const angle=i*Math.PI/points;
+            const r=i%2===0?size/2:size/4;
+            const x=Math.cos(angle)*r;
+            const y=Math.sin(angle)*r;
+            if(i===0) ctx.moveTo(x,y); else ctx.lineTo(x,y);
+        }
+        ctx.closePath();
     }
     ctx.fill();
 }
@@ -170,8 +192,10 @@ function animate(time){
                 ctx.save();
                 ctx.translate(x,y);
                 ctx.rotate(rot);
-                const jitter=1+(Math.random()*2-1)*params.sizeVar;
-                drawShape(ctx,params.shape,step*0.8*jitter);
+                const range=params.sizeMax-params.sizeMin;
+                let size=params.sizeMin+Math.random()*range;
+                size*=1+(Math.random()*2-1)*params.sizeVar;
+                drawShape(ctx,params.shape,step*0.8*size);
                 ctx.restore();
             }
         }
@@ -191,7 +215,7 @@ function createSettings(){
         div.className='layer-config';
         div.innerHTML=`<strong>Layer ${idx+1}</strong>`;
         const fields=[
-            ['shape','select',['triangle','square','hexagon']],
+            ['shape','select',['triangle','square','hexagon','circle','diamond','star']],
             ['scaleX','number'],
             ['scaleY','number'],
             ['offsetX','number'],
@@ -201,6 +225,8 @@ function createSettings(){
             ['opacity','number'],
             ['backdropBlur','number'],
             ['sizeVar','number'],
+            ['sizeMin','number'],
+            ['sizeMax','number'],
             ['speed','number'],
             ['parallax','number'],
             ['driftSpeed','number'],


### PR DESCRIPTION
## Summary
- support new shapes (circle, diamond and star) in layered visualizer
- allow each layer to set minimum and maximum shape size
- update settings panel with the new controls
- document the new options in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68531ad6abc08325a03a88bbd2e23297