### PR TITLE
Add global scale controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,10 @@ around instead of overlapping when their sizes change. Individual shapes may
 occasionally twinkle, fading quickly to white and back to their layer colour.
 Click **Enable Mic** to let the layers pulse and spin in response to sound
 captured from your microphone. A new **Audio Boost** slider controls how
-strongly the audio randomly modulates every layer parameter.
+strongly the audio randomly modulates every layer parameter. Two global sliders
+labelled **Global Scale X** and **Global Scale Y** multiply all layer scaling
+so you can spread out or compress the entire visualization while keeping
+relative spacing intact.
 The current configuration is now compressed and encoded in the page URL so you
 can share your designs with shorter links.
 

--- a/layered/index.html
+++ b/layered/index.html
@@ -44,6 +44,26 @@
           step="0.1"
           value="1"
       /></label>
+      <label
+        >Global Scale X
+        <input
+          id="globalScaleX"
+          type="range"
+          min="0.5"
+          max="4"
+          step="0.1"
+          value="1"
+      /></label>
+      <label
+        >Global Scale Y
+        <input
+          id="globalScaleY"
+          type="range"
+          min="0.5"
+          max="4"
+          step="0.1"
+          value="1"
+      /></label>
     </div>
     <div id="settings" class="settings-panel"></div>
     <script>
@@ -263,6 +283,8 @@
         audioLevel = 0,
         micEnabled = false;
       let audioBoost = 1;
+      let globalScaleX = 1,
+        globalScaleY = 1;
 
       async function toggleMic() {
         if (!micEnabled) {
@@ -301,8 +323,8 @@
         const step = 40;
         const w = layer.canvas.width;
         const h = layer.canvas.height;
-        const sx = layer.params.scaleX;
-        const sy = layer.params.scaleY;
+        const sx = layer.params.scaleX * globalScaleX;
+        const sy = layer.params.scaleY * globalScaleY;
         for (let x = -w; x < w; x += step * sx) {
           for (let y = -h; y < h; y += step * sy) {
             shapes.push({
@@ -676,6 +698,14 @@
       document.getElementById("micToggle").onclick = toggleMic;
       document.getElementById("audioBoost").oninput = (e) => {
         audioBoost = parseFloat(e.target.value);
+      };
+      document.getElementById("globalScaleX").oninput = (e) => {
+        globalScaleX = parseFloat(e.target.value);
+        layers.forEach(initShapes);
+      };
+      document.getElementById("globalScaleY").oninput = (e) => {
+        globalScaleY = parseFloat(e.target.value);
+        layers.forEach(initShapes);
       };
     </script>
   </body>


### PR DESCRIPTION
## Summary
- add global sliders to multiply layer scale
- support new sliders in initialization and events
- document global scaling in README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68533dabb36c8325be80ecd86ab60ac4