### PR TITLE
Add roadmap prototype HTML demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ These projects share a couple of design goals:
 - **Mandelbrot Visualizer** – found in `mandelbrot/`.
 - **Particles Visualizer** – found in `particles/`.
 - **Spirograph Visualizer** – found in `spirograph/`.
+- **Node Garden Prototype** – found in `nodegarden/`.
+- **Flow Field Particles Prototype** – found in `flowfield/`.
+- **Firework Fiesta Prototype** – found in `fireworks/`.
 
 ## Layered Visualizer
 
@@ -80,3 +83,18 @@ particle population is split between them and the overall particle count.
 
 Open `spirograph/index.html` to watch spirograph curves being drawn. Sliders
 control the outer and inner radii, the pen offset and the drawing speed.
+
+## Node Garden Prototype
+
+Open `nodegarden/index.html` to see a simple garden of swaying stems. Use the
+settings panel to change how many stems appear and how strong the wind blows.
+
+## Flow Field Particles Prototype
+
+Open `flowfield/index.html` for particles that follow a basic vector field.
+Sliders adjust particle count and how tightly the field curls.
+
+## Firework Fiesta Prototype
+
+Open `fireworks/index.html` to launch colourful bursts. The single slider
+controls how frequently fireworks appear.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -101,3 +101,12 @@ Agents should avoid implementing items listed under **Long-Term Objectives** unl
   2. Draw particles that align along the resulting field lines.
   3. Tune magnet strength, number of particles and line width through settings.
   4. Let users drag magnets around to shape mesmerizing patterns.
+
+## Implemented Prototypes
+
+The following ideas from the brainstorm currently have basic HTML
+implementations:
+
+- Node Garden
+- Flow Field Particles
+- Firework Fiesta

--- a/fireworks/index.html
+++ b/fireworks/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Firework Fiesta Prototype</title>
+<link rel="stylesheet" href="../common.css">
+</head>
+<body>
+<canvas id="canvas"></canvas>
+<div class="controls">
+  <button id="toggleSettings">Toggle Settings</button>
+</div>
+<div id="settings" class="settings-panel">
+  <label>Launch Rate: <input type="range" id="launchRate" min="0" max="5" step="0.1" value="1"></label>
+</div>
+<script>
+const canvas=document.getElementById('canvas');
+const ctx=canvas.getContext('2d');
+let width,height;resize();
+window.addEventListener('resize',resize);
+function resize(){width=canvas.width=window.innerWidth;height=canvas.height=window.innerHeight;}
+const fireworks=[];
+function spawn(){fireworks.push({x:Math.random()*width,y:height,vy:-Math.random()*6-4,life:0});}
+function update(){
+  const rate=parseFloat(document.getElementById('launchRate').value);
+  if(Math.random()<rate*0.02) spawn();
+  ctx.fillStyle='rgba(0,0,0,0.25)';ctx.fillRect(0,0,width,height);
+  for(let i=fireworks.length-1;i>=0;i--){
+    const f=fireworks[i];
+    if(f.explode){
+      f.sparks.forEach(s=>{
+        s.x+=s.vx;s.y+=s.vy;s.vy+=0.05;s.life++;
+        ctx.fillStyle=`hsla(${f.hue},100%,60%,${1-s.life/50})`;
+        ctx.fillRect(s.x,s.y,2,2);
+      });
+      if(f.life>50) fireworks.splice(i,1);
+      continue;
+    }
+    f.y+=f.vy;f.vy+=0.05;f.life++;
+    ctx.fillStyle='white';ctx.fillRect(f.x,f.y,2,2);
+    if(f.vy>0){
+      f.explode=true;f.hue=Math.random()*360;f.sparks=[];
+      for(let j=0;j<30;j++){
+        const a=Math.random()*Math.PI*2;const sp=Math.random()*3+1;
+        f.sparks.push({x:f.x,y:f.y,vx:Math.cos(a)*sp,vy:Math.sin(a)*sp,life:0});
+      }
+    }
+  }
+  requestAnimationFrame(update);
+}
+update();
+document.getElementById('toggleSettings').onclick=()=>{const s=document.getElementById('settings');s.style.display=s.style.display?'':'block';};
+</script>
+</body>
+</html>

--- a/flowfield/index.html
+++ b/flowfield/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Flow Field Particles Prototype</title>
+<link rel="stylesheet" href="../common.css">
+</head>
+<body>
+<canvas id="canvas"></canvas>
+<div class="controls">
+  <button id="toggleSettings">Toggle Settings</button>
+</div>
+<div id="settings" class="settings-panel">
+  <label>Particles: <input type="range" id="particleCount" min="50" max="400" value="200"></label>
+  <label>Field Scale: <input type="range" id="fieldScale" min="20" max="100" value="60"></label>
+</div>
+<script>
+const canvas=document.getElementById('canvas');
+const ctx=canvas.getContext('2d');
+let width,height;resize();
+window.addEventListener('resize',resize);
+function resize(){width=canvas.width=window.innerWidth;height=canvas.height=window.innerHeight;}
+let count=200;let scale=60;const particles=[];
+function reset(){particles.length=0;for(let i=0;i<count;i++){particles.push({x:Math.random()*width,y:Math.random()*height});}}
+function update(){
+  count=parseInt(document.getElementById('particleCount').value,10);
+  scale=parseFloat(document.getElementById('fieldScale').value);
+  if(particles.length!==count) reset();
+  ctx.fillStyle='rgba(0,0,0,0.1)';ctx.fillRect(0,0,width,height);
+  ctx.fillStyle='white';
+  particles.forEach(p=>{
+    const angle=Math.sin(p.y/scale)+Math.cos(p.x/scale);
+    p.x+=Math.cos(angle);p.y+=Math.sin(angle);
+    if(p.x<0) p.x+=width;if(p.x>width) p.x-=width;
+    if(p.y<0) p.y+=height;if(p.y>height) p.y-=height;
+    ctx.fillRect(p.x,p.y,2,2);
+  });
+  requestAnimationFrame(update);
+}
+reset();
+update();
+document.getElementById('toggleSettings').onclick=()=>{const s=document.getElementById('settings');s.style.display=s.style.display?'':'block';};
+</script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -18,6 +18,9 @@
         <li><a href="mandelbrot/index.html">Mandelbrot Visualizer</a></li>
         <li><a href="particles/index.html">Particles Visualizer</a></li>
         <li><a href="spirograph/index.html">Spirograph Visualizer</a></li>
+        <li><a href="nodegarden/index.html">Node Garden Prototype</a></li>
+        <li><a href="flowfield/index.html">Flow Field Particles Prototype</a></li>
+        <li><a href="fireworks/index.html">Firework Fiesta Prototype</a></li>
     </ul>
 </body>
 </html>

--- a/nodegarden/index.html
+++ b/nodegarden/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Node Garden Prototype</title>
+<link rel="stylesheet" href="../common.css">
+</head>
+<body>
+<canvas id="canvas"></canvas>
+<div class="controls">
+  <button id="toggleSettings">Toggle Settings</button>
+</div>
+<div id="settings" class="settings-panel">
+  <label>Stems: <input type="range" id="stemCount" min="5" max="40" value="20"></label>
+  <label>Wind Speed: <input type="range" id="windSpeed" min="0" max="5" step="0.1" value="1"></label>
+</div>
+<script>
+const canvas=document.getElementById('canvas');
+const ctx=canvas.getContext('2d');
+let width,height;resize();
+window.addEventListener('resize',resize);
+function resize(){width=canvas.width=window.innerWidth;height=canvas.height=window.innerHeight;}
+let stems=20;let speed=1;let t=0;
+function update(){
+  stems=parseInt(document.getElementById('stemCount').value,10);
+  speed=parseFloat(document.getElementById('windSpeed').value);
+  t+=0.01*speed;
+  ctx.clearRect(0,0,width,height);
+  for(let i=0;i<stems;i++){
+    const x=(i+0.5)*width/stems;
+    const sway=Math.sin(t+i)*40;
+    ctx.beginPath();
+    ctx.moveTo(x,height);
+    ctx.quadraticCurveTo(x+sway,height*0.5,x+sway*1.5,height*0.2);
+    ctx.strokeStyle=`hsl(${120+i*10},70%,60%)`;
+    ctx.lineWidth=2;
+    ctx.stroke();
+  }
+  requestAnimationFrame(update);
+}
+update();
+document.getElementById('toggleSettings').onclick=()=>{const s=document.getElementById('settings');s.style.display=s.style.display?'':'block';};
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement Node Garden prototype
- implement Flow Field Particles prototype
- implement Firework Fiesta prototype
- list the prototypes in README and update descriptions
- note prototypes in ROADMAP
- link prototypes from the launcher

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68534eda00d88325a849de70a6695fef